### PR TITLE
fix: replace http with https in blog featureImage URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- Replace http with https in blog featureImage URLs

--- a/content/blog/feed-senza-tracciamento.md
+++ b/content/blog/feed-senza-tracciamento.md
@@ -1,7 +1,7 @@
 ---
 title: "Il feed di Pensieri in codice senza tracciamento o pubblicità"
 date: 2024-02-07T10:00:00+02:00
-featureImage: http://cdn.pensieriincodice.it/images/feed-senza-tracciamento-feature.jpg
+featureImage: https://cdn.pensieriincodice.it/images/feed-senza-tracciamento-feature.jpg
 image: images/feed-senza-tracciamento-thumbnail.jpg
 tags:
 - Feed

--- a/content/blog/nuove-statistiche-di-pensieri-in-codice.md
+++ b/content/blog/nuove-statistiche-di-pensieri-in-codice.md
@@ -1,7 +1,7 @@
 ---
 title: "Le nuove statistiche di Pensieri in codice"
 date: 2024-01-18T10:00:00+02:00
-featureImage: http://cdn.pensieriincodice.it/images/nuove-statistiche-di-pensieri-in-codice-feature.jpg
+featureImage: https://cdn.pensieriincodice.it/images/nuove-statistiche-di-pensieri-in-codice-feature.jpg
 image: images/nuove-statistiche-di-pensieri-in-codice-thumbnail.jpg
 tags:
 - Statistiche

--- a/content/blog/nuovi-gadget-di-pensieri-in-codice.md
+++ b/content/blog/nuovi-gadget-di-pensieri-in-codice.md
@@ -1,7 +1,7 @@
 ---
 title: "I nuovi gadget di Pensieri in codice"
 date: 2024-02-05T19:00:00+02:00
-featureImage: http://cdn.pensieriincodice.it/images/nuovi-gadget-di-pensieri-in-codice-feature.jpeg
+featureImage: https://cdn.pensieriincodice.it/images/nuovi-gadget-di-pensieri-in-codice-feature.jpeg
 image: images/nuovi-gadget-di-pensieri-in-codice-thumbnail.jpeg
 tags:
 - Gadget


### PR DESCRIPTION
## Summary

- Tre post del blog referenziavano immagini CDN tramite `http://`, causando warning di Mixed Content sul sito HTTPS
- Aggiornati gli URL di `featureImage` da `http://` a `https://` nei file:
  - `content/blog/feed-senza-tracciamento.md`
  - `content/blog/nuove-statistiche-di-pensieri-in-codice.md`
  - `content/blog/nuovi-gadget-di-pensieri-in-codice.md`

## Test plan

- [ ] Verificare che le immagini delle news si carichino correttamente in produzione
- [ ] Aprire la console del browser sulla home page e verificare l'assenza di warning Mixed Content