### PR TITLE
fix: replace http with https in blog featureImage URLs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -183,6 +183,11 @@ name = "NextDNS"
 url = "https://nextdns.io/?from=pmy29ab3"
 
 [[params.support.special_thanks]]
+name = "Patrizia Giannantoni"
+url = "#"
+note = "Revisione contenuti"
+
+[[params.support.special_thanks]]
 name = "Simone Pizzi"
 url = "https://simonepizzi.runtimeradio.it/"
 note = "Design di questo sito"

--- a/content/blog/feed-senza-tracciamento.md
+++ b/content/blog/feed-senza-tracciamento.md
@@ -1,7 +1,7 @@
 ---
 title: "Il feed di Pensieri in codice senza tracciamento o pubblicità"
 date: 2024-02-07T10:00:00+02:00
-featureImage: http://cdn.pensieriincodice.it/images/feed-senza-tracciamento-feature.jpg
+featureImage: https://cdn.pensieriincodice.it/images/feed-senza-tracciamento-feature.jpg
 image: images/feed-senza-tracciamento-thumbnail.jpg
 tags:
 - Feed

--- a/content/blog/nuove-statistiche-di-pensieri-in-codice.md
+++ b/content/blog/nuove-statistiche-di-pensieri-in-codice.md
@@ -1,7 +1,7 @@
 ---
 title: "Le nuove statistiche di Pensieri in codice"
 date: 2024-01-18T10:00:00+02:00
-featureImage: http://cdn.pensieriincodice.it/images/nuove-statistiche-di-pensieri-in-codice-feature.jpg
+featureImage: https://cdn.pensieriincodice.it/images/nuove-statistiche-di-pensieri-in-codice-feature.jpg
 image: images/nuove-statistiche-di-pensieri-in-codice-thumbnail.jpg
 tags:
 - Statistiche

--- a/content/blog/nuovi-gadget-di-pensieri-in-codice.md
+++ b/content/blog/nuovi-gadget-di-pensieri-in-codice.md
@@ -1,7 +1,7 @@
 ---
 title: "I nuovi gadget di Pensieri in codice"
 date: 2024-02-05T19:00:00+02:00
-featureImage: http://cdn.pensieriincodice.it/images/nuovi-gadget-di-pensieri-in-codice-feature.jpeg
+featureImage: https://cdn.pensieriincodice.it/images/nuovi-gadget-di-pensieri-in-codice-feature.jpeg
 image: images/nuovi-gadget-di-pensieri-in-codice-thumbnail.jpeg
 tags:
 - Gadget


### PR DESCRIPTION
## Summary

- Replace http with https in featureImage URLs of blog posts to fix mixed content warnings
- Add CHANGELOG entry for the fix
- Add special thanks entry in config.toml (commit fatto sul branch sbagliato, incluso qui)

## Test plan

- [x] Verificare assenza di mixed content warnings nella console del browser sulle pagine blog
- [x] Verificare che le featureImage si carichino correttamente via https