### PR TITLE
feat: add Piattaforme section and unify navigation icons

### DIFF
--- a/content/piattaforme/_index.md
+++ b/content/piattaforme/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Piattaforme"
+description: "Tutte le piattaforme dove puoi ascoltare Pensieri in codice."
+draft: false
+---

--- a/themes/picnew/layouts/_default/baseof.html
+++ b/themes/picnew/layouts/_default/baseof.html
@@ -80,7 +80,7 @@
                 </li>
                 <li>
                 <a href="{{ "episodes/" | relURL }}" class="mobile-nav-link flex items-center space-x-4 px-3 py-3 rounded-lg hover:bg-white/5 transition-all text-pod-gray hover:text-white">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 18v-6a9 9 0 0 1 18 0v6"/><path d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z"/></svg>
                     <span class="font-medium">Episodi</span>
                 </a>
                 </li>
@@ -118,6 +118,12 @@
                 <a href="{{ "sostieni/" | relURL }}" class="mobile-nav-link flex items-center space-x-4 px-3 py-3 rounded-lg hover:bg-white/5 transition-all text-pod-orange">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
                     <span class="font-medium">Sostieni</span>
+                </a>
+                </li>
+                <li>
+                <a href="{{ "piattaforme/" | relURL }}" class="mobile-nav-link flex items-center space-x-4 px-3 py-3 rounded-lg hover:bg-white/5 transition-all text-pod-gray hover:text-white">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.9 19.1C1 15.2 1 8.8 4.9 4.9"/><path d="M7.8 16.2c-2.3-2.3-2.3-6.1 0-8.5"/><circle cx="12" cy="12" r="2"/><path d="M16.2 7.8c2.3 2.3 2.3 6.1 0 8.5"/><path d="M19.1 4.9C23 8.8 23 15.2 19.1 19.1"/></svg>
+                    <span class="font-medium">Piattaforme</span>
                 </a>
                 </li>
                 <li>

--- a/themes/picnew/layouts/contatti/list.html
+++ b/themes/picnew/layouts/contatti/list.html
@@ -1,47 +1,9 @@
 {{ define "main" }}
-{{- $rss      := where .Site.Params.platforms "type" "rss" -}}
-{{- $podcasts := where .Site.Params.platforms "type" "podcast" -}}
 {{- $socials  := where .Site.Params.social "type" "social" -}}
 {{- $community := where .Site.Params.social "type" "community" -}}
 <div class="max-w-2xl mx-auto">
     <h1 class="text-4xl font-extrabold tracking-tight mb-4">Contatti</h1>
     <p class="text-pod-gray mb-12">Tutti i modi per entrare in contatto, seguire il podcast e far parte della community.</p>
-
-    {{/* Aggregatori podcast */}}
-    {{ if or $rss $podcasts }}
-    <section class="mb-10">
-        <h2 class="text-xs font-bold uppercase tracking-widest text-pod-orange mb-4">Ascolta il podcast</h2>
-        <div class="space-y-3">
-            {{ range $rss }}
-            {{ $url := .url }}
-            {{ if not (hasPrefix .url "http") }}{{ $url = .url | relURL }}{{ end }}
-            <a href="{{ $url }}"
-                class="flex items-center space-x-4 p-4 bg-pod-card border border-white/5 rounded-xl hover:border-pod-orange/30 transition-all group">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
-                    stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                    class="text-pod-gray group-hover:text-pod-orange transition-colors flex-shrink-0">
-                    <path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1"/>
-                </svg>
-                <div>
-                    <div class="font-semibold group-hover:text-pod-orange transition-colors">{{ .name }}</div>
-                    <div class="text-xs text-pod-gray">Feed RSS del podcast</div>
-                </div>
-            </a>
-            {{ end }}
-            {{ range $podcasts }}
-            {{ $parsed := urls.Parse .url }}
-            <a href="{{ .url }}" target="_blank" rel="noopener"
-                class="flex items-center space-x-4 p-4 bg-pod-card border border-white/5 rounded-xl hover:border-pod-orange/30 transition-all group">
-                <img src="https://www.google.com/s2/favicons?domain={{ $parsed.Host }}&sz=32" alt="{{ .name }}" class="w-6 h-6 flex-shrink-0">
-                <div>
-                    <div class="font-semibold group-hover:text-pod-orange transition-colors">{{ .name }}</div>
-                    <div class="text-xs text-pod-gray">{{ .url }}</div>
-                </div>
-            </a>
-            {{ end }}
-        </div>
-    </section>
-    {{ end }}
 
     {{/* Social */}}
     {{ if $socials }}

--- a/themes/picnew/layouts/partials/header.html
+++ b/themes/picnew/layouts/partials/header.html
@@ -76,30 +76,28 @@
             </div>
         </div>
 
-        {{/* Dropdown "Segui": raccoglie RSS, piattaforme, social, community, email */}}
-        <div class="relative" id="follow-dropdown-container">
-            <button id="follow-dropdown-toggle"
+        {{- $rss      := where .Site.Params.platforms "type" "rss" -}}
+        {{- $podcasts := where .Site.Params.platforms "type" "podcast" -}}
+        {{- $socials  := where .Site.Params.social "type" "social" -}}
+        {{- $community := where .Site.Params.social "type" "community" -}}
+
+        {{/* Dropdown Piattaforme */}}
+        {{ if or $rss $podcasts }}
+        <div class="relative" id="platforms-dropdown-container">
+            <button id="platforms-dropdown-toggle"
                 class="flex items-center gap-1.5 text-pod-gray hover:text-pod-orange transition-colors flex-shrink-0 text-sm font-mono"
-                aria-label="Segui il podcast su..." title="Segui su..." aria-expanded="false" aria-controls="follow-dropdown" aria-haspopup="true">
+                aria-label="Ascolta su..." title="Ascolta su..." aria-expanded="false" aria-controls="platforms-dropdown" aria-haspopup="true">
                 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
                     stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                    <path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>
+                    <path d="M4.9 19.1C1 15.2 1 8.8 4.9 4.9"/><path d="M7.8 16.2c-2.3-2.3-2.3-6.1 0-8.5"/><circle cx="12" cy="12" r="2"/><path d="M16.2 7.8c2.3 2.3 2.3 6.1 0 8.5"/><path d="M19.1 4.9C23 8.8 23 15.2 19.1 19.1"/>
                 </svg>
                 <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none"
-                    stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" id="follow-chevron" aria-hidden="true">
+                    stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" id="platforms-chevron" aria-hidden="true">
                     <polyline points="6 9 12 15 18 9"/>
                 </svg>
             </button>
-
-            <div id="follow-dropdown" role="menu"
+            <div id="platforms-dropdown" role="menu"
                 class="hidden absolute right-0 top-full mt-2 w-52 bg-pod-card border border-white/10 rounded-xl shadow-2xl shadow-black/40 py-2 z-50">
-
-                {{- $rss      := where .Site.Params.platforms "type" "rss" -}}
-                {{- $podcasts := where .Site.Params.platforms "type" "podcast" -}}
-                {{- $socials  := where .Site.Params.social "type" "social" -}}
-                {{- $community := where .Site.Params.social "type" "community" -}}
-
-                {{/* RSS */}}
                 {{ range $rss }}
                 {{ $url := .url }}
                 {{ if not (hasPrefix .url "http") }}{{ $url = .url | relURL }}{{ end }}
@@ -111,51 +109,57 @@
                     <span>{{ .name }}</span>
                 </a>
                 {{ end }}
-
-                {{/* Separatore RSS / Piattaforme */}}
                 {{ if and $rss $podcasts }}<div class="my-1 border-t border-white/5"></div>{{ end }}
-
-                {{/* Piattaforme podcast */}}
                 {{ range $podcasts }}
                 {{ $parsed := urls.Parse .url }}
                 <a href="{{ .url }}" target="_blank" rel="noopener" title="{{ .name }}"
                     class="flex items-center gap-3 py-2 text-sm text-pod-gray hover:text-white hover:bg-white/5 transition-colors whitespace-nowrap" style="padding-left: 1rem; padding-right: 2rem">
                     <img src="https://www.google.com/s2/favicons?domain={{ $parsed.Host }}&sz=32"
-                        alt="{{ .name }}" width="15" height="15"
-                        class="w-[15px] h-[15px] flex-shrink-0">
+                        alt="{{ .name }}" width="15" height="15" class="w-[15px] h-[15px] flex-shrink-0">
                     <span>{{ .name }}</span>
                 </a>
                 {{ end }}
+            </div>
+        </div>
+        {{ end }}
 
-                {{/* Separatore Piattaforme / Social */}}
-                {{ if and (or $rss $podcasts) (or $socials $community) }}<div class="my-1 border-t border-white/5"></div>{{ end }}
-
-                {{/* Social */}}
+        {{/* Dropdown Social/Contatti */}}
+        {{ if or $socials $community .Site.Params.podcast.email }}
+        <div class="relative" id="social-dropdown-container">
+            <button id="social-dropdown-toggle"
+                class="flex items-center gap-1.5 text-pod-gray hover:text-pod-orange transition-colors flex-shrink-0 text-sm font-mono"
+                aria-label="Seguici su..." title="Seguici su..." aria-expanded="false" aria-controls="social-dropdown" aria-haspopup="true">
+                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
+                </svg>
+                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" id="social-chevron" aria-hidden="true">
+                    <polyline points="6 9 12 15 18 9"/>
+                </svg>
+            </button>
+            <div id="social-dropdown" role="menu"
+                class="hidden absolute right-0 top-full mt-2 w-52 bg-pod-card border border-white/10 rounded-xl shadow-2xl shadow-black/40 py-2 z-50">
                 {{ range $socials }}
                 {{ $parsed := urls.Parse .url }}
                 <a href="{{ .url }}" target="_blank" rel="noopener" title="{{ .name }}"
                     class="flex items-center gap-3 py-2 text-sm text-pod-gray hover:text-white hover:bg-white/5 transition-colors whitespace-nowrap" style="padding-left: 1rem; padding-right: 2rem">
                     <img src="https://www.google.com/s2/favicons?domain={{ $parsed.Host }}&sz=32"
-                        alt="{{ .name }}" width="15" height="15"
-                        class="w-[15px] h-[15px] flex-shrink-0">
+                        alt="{{ .name }}" width="15" height="15" class="w-[15px] h-[15px] flex-shrink-0">
                     <span>{{ .name }}</span>
                 </a>
                 {{ end }}
-
-                {{/* Community */}}
                 {{ range $community }}
                 {{ $parsed := urls.Parse .url }}
                 <a href="{{ .url }}" target="_blank" rel="noopener" title="{{ .name }}"
                     class="flex items-center gap-3 py-2 text-sm text-pod-gray hover:text-white hover:bg-white/5 transition-colors whitespace-nowrap" style="padding-left: 1rem; padding-right: 2rem">
                     <img src="https://www.google.com/s2/favicons?domain={{ $parsed.Host }}&sz=32"
-                        alt="{{ .name }}" width="15" height="15"
-                        class="w-[15px] h-[15px] flex-shrink-0">
+                        alt="{{ .name }}" width="15" height="15" class="w-[15px] h-[15px] flex-shrink-0">
                     <span>{{ .name }}</span>
                 </a>
                 {{ end }}
-
-                {{/* Separatore / Email */}}
-                {{ if .Site.Params.podcast.email }}<div class="my-1 border-t border-white/5"></div>
+                {{ if .Site.Params.podcast.email }}
+                {{ if or $socials $community }}<div class="my-1 border-t border-white/5"></div>{{ end }}
                 <a href="mailto:{{ .Site.Params.podcast.email }}" title="Email"
                     class="flex items-center gap-3 py-2 text-sm text-pod-gray hover:text-white hover:bg-white/5 transition-colors whitespace-nowrap" style="padding-left: 1rem; padding-right: 2rem">
                     <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none"
@@ -167,14 +171,16 @@
                 {{ end }}
             </div>
         </div>
+        {{ end }}
     </div>
 </header>
 
 <script>
 (function() {
     var dropdowns = [
-        { toggleId: 'follow-dropdown-toggle', dropdownId: 'follow-dropdown', chevronId: 'follow-chevron', containerId: 'follow-dropdown-container' },
-        { toggleId: 'theme-toggle',           dropdownId: 'theme-dropdown',  chevronId: 'theme-chevron',  containerId: 'theme-dropdown-container'  },
+        { toggleId: 'platforms-dropdown-toggle', dropdownId: 'platforms-dropdown', chevronId: 'platforms-chevron', containerId: 'platforms-dropdown-container' },
+        { toggleId: 'social-dropdown-toggle',    dropdownId: 'social-dropdown',    chevronId: 'social-chevron',    containerId: 'social-dropdown-container'    },
+        { toggleId: 'theme-toggle',              dropdownId: 'theme-dropdown',     chevronId: 'theme-chevron',     containerId: 'theme-dropdown-container'     },
     ];
 
     function closeAll(except) {

--- a/themes/picnew/layouts/partials/sidebar.html
+++ b/themes/picnew/layouts/partials/sidebar.html
@@ -23,9 +23,7 @@
             <div class="flex-shrink-0">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
                     stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                    <path d="M9 18V5l12-2v13" />
-                    <circle cx="6" cy="18" r="3" />
-                    <circle cx="18" cy="16" r="3" />
+                    <path d="M3 18v-6a9 9 0 0 1 18 0v6"/><path d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z"/>
                 </svg>
             </div>
             <span class="ml-4 opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap overflow-hidden">Episodi</span>
@@ -95,6 +93,16 @@
                 </svg>
             </div>
             <span class="ml-4 opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap overflow-hidden">Sostieni</span>
+        </a>
+        <a href="{{ "piattaforme/" | relURL }}" aria-label="Piattaforme"
+        class="flex items-center p-2 rounded-lg hover:bg-white/5 transition-all duration-300 {{ if and .File (eq .File.Path "piattaforme/_index.md") }}active-link text-white{{ else }}text-pod-gray hover:text-white{{ end }}">
+        <div class="flex-shrink-0">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M4.9 19.1C1 15.2 1 8.8 4.9 4.9"/><path d="M7.8 16.2c-2.3-2.3-2.3-6.1 0-8.5"/><circle cx="12" cy="12" r="2"/><path d="M16.2 7.8c2.3 2.3 2.3 6.1 0 8.5"/><path d="M19.1 4.9C23 8.8 23 15.2 19.1 19.1"/>
+            </svg>
+        </div>
+        <span class="ml-4 opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap overflow-hidden">Piattaforme</span>
         </a>
         <a href="{{ "contatti/" | relURL }}" aria-label="Contatti"
         class="flex items-center p-2 rounded-lg hover:bg-white/5 transition-all duration-300 {{ if and .File (eq .File.Path "contatti/_index.md") }}active-link text-white{{ else }}text-pod-gray hover:text-white{{ end }}">

--- a/themes/picnew/layouts/piattaforme/list.html
+++ b/themes/picnew/layouts/piattaforme/list.html
@@ -1,0 +1,43 @@
+{{ define "main" }}
+{{- $rss      := where .Site.Params.platforms "type" "rss" -}}
+{{- $podcasts := where .Site.Params.platforms "type" "podcast" -}}
+<div class="max-w-2xl mx-auto">
+    <h1 class="text-4xl font-extrabold tracking-tight mb-4">Piattaforme</h1>
+    <p class="text-pod-gray mb-12">Tutti i posti dove puoi ascoltare Pensieri in codice.</p>
+
+    {{ if or $rss $podcasts }}
+    <section class="mb-10">
+        <h2 class="text-xs font-bold uppercase tracking-widest text-pod-orange mb-4">Ascolta il podcast</h2>
+        <div class="space-y-3">
+            {{ range $rss }}
+            {{ $url := .url }}
+            {{ if not (hasPrefix .url "http") }}{{ $url = .url | relURL }}{{ end }}
+            <a href="{{ $url }}"
+                class="flex items-center space-x-4 p-4 bg-pod-card border border-white/5 rounded-xl hover:border-pod-orange/30 transition-all group">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                    class="text-pod-gray group-hover:text-pod-orange transition-colors flex-shrink-0">
+                    <path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1"/>
+                </svg>
+                <div>
+                    <div class="font-semibold group-hover:text-pod-orange transition-colors">{{ .name }}</div>
+                    <div class="text-xs text-pod-gray">Feed RSS del podcast</div>
+                </div>
+            </a>
+            {{ end }}
+            {{ range $podcasts }}
+            {{ $parsed := urls.Parse .url }}
+            <a href="{{ .url }}" target="_blank" rel="noopener"
+                class="flex items-center space-x-4 p-4 bg-pod-card border border-white/5 rounded-xl hover:border-pod-orange/30 transition-all group">
+                <img src="https://www.google.com/s2/favicons?domain={{ $parsed.Host }}&sz=32" alt="{{ .name }}" class="w-6 h-6 flex-shrink-0">
+                <div>
+                    <div class="font-semibold group-hover:text-pod-orange transition-colors">{{ .name }}</div>
+                    <div class="text-xs text-pod-gray">{{ .url }}</div>
+                </div>
+            </a>
+            {{ end }}
+        </div>
+    </section>
+    {{ end }}
+</div>
+{{ end }}


### PR DESCRIPTION
## Summary

- Aggiunta nuova pagina `/piattaforme` con RSS feed e tutte le piattaforme podcast
- Spostati i link alle piattaforme fuori da Contatti (che ora mostra solo social, community ed email)
- Dropdown header diviso in due: piattaforme (icona radio) e contatti (icona busta)
- Icona Episodi aggiornata a cuffie in sidebar, menu mobile e header

## Test plan

- [x] Verificare che `/piattaforme` mostri correttamente RSS e tutte le piattaforme
- [x] Verificare che Contatti non mostri più la sezione "Ascolta il podcast"
- [x] Verificare le icone corrette in sidebar per Episodi e Piattaforme
- [x] Verificare i due dropdown separati nell'header con contenuti corretti
- [x] Verificare menu mobile con voci Piattaforme e Contatti

🤖 Generated with [Claude Code](https://claude.com/claude-code)