### PR TITLE
fix: prevent TypeError during Turbo navigation on permanent elements

### DIFF
--- a/themes/picnew/layouts/_default/baseof.html
+++ b/themes/picnew/layouts/_default/baseof.html
@@ -274,8 +274,10 @@
             if (e.target.closest('#mobile-menu-toggle')) openMobileMenu();
         });
 
-        document.getElementById('mobile-menu-overlay').addEventListener('click', closeMobileMenu);
-        document.getElementById('mobile-menu-close').addEventListener('click', closeMobileMenu);
+        var mobileOverlay = document.getElementById('mobile-menu-overlay');
+        if (mobileOverlay) mobileOverlay.addEventListener('click', closeMobileMenu);
+        var mobileClose = document.getElementById('mobile-menu-close');
+        if (mobileClose) mobileClose.addEventListener('click', closeMobileMenu);
         document.querySelectorAll('.mobile-nav-link').forEach(function(link) {
             link.addEventListener('click', closeMobileMenu);
         });

--- a/themes/picnew/layouts/partials/header.html
+++ b/themes/picnew/layouts/partials/header.html
@@ -177,14 +177,14 @@
 
 <script>
 (function() {
-    var dropdowns = [
+    var dropdownConfigs = [
         { toggleId: 'platforms-dropdown-toggle', dropdownId: 'platforms-dropdown', chevronId: 'platforms-chevron', containerId: 'platforms-dropdown-container' },
         { toggleId: 'social-dropdown-toggle',    dropdownId: 'social-dropdown',    chevronId: 'social-chevron',    containerId: 'social-dropdown-container'    },
         { toggleId: 'theme-toggle',              dropdownId: 'theme-dropdown',     chevronId: 'theme-chevron',     containerId: 'theme-dropdown-container'     },
     ];
 
     function closeAll(except) {
-        dropdowns.forEach(function(d) {
+        dropdownConfigs.forEach(function(d) {
             if (d.dropdownId === except) return;
             var el = document.getElementById(d.dropdownId);
             var ch = document.getElementById(d.chevronId);
@@ -195,46 +195,64 @@
         });
     }
 
-    dropdowns.forEach(function(d) {
-        var toggle   = document.getElementById(d.toggleId);
-        var dropdown = document.getElementById(d.dropdownId);
-        var chevron  = document.getElementById(d.chevronId);
-        if (!toggle || !dropdown) return;
-
-        toggle.addEventListener('click', function(e) {
-            e.stopPropagation();
-            var isOpen = !dropdown.classList.contains('hidden');
-            closeAll(d.dropdownId);
-            dropdown.classList.toggle('hidden', isOpen);
-            toggle.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
-            if (chevron) chevron.style.transform = isOpen ? '' : 'rotate(180deg)';
-        });
-
-        document.addEventListener('click', function(e) {
+    function handleOutsideClick(e) {
+        dropdownConfigs.forEach(function(d) {
             var container = document.getElementById(d.containerId);
+            var dropdown  = document.getElementById(d.dropdownId);
+            var toggle    = document.getElementById(d.toggleId);
+            var chevron   = document.getElementById(d.chevronId);
+            if (!dropdown || !toggle) return;
             if (container && !container.contains(e.target)) {
                 dropdown.classList.add('hidden');
                 toggle.setAttribute('aria-expanded', 'false');
                 if (chevron) chevron.style.transform = '';
             }
         });
+    }
 
-        // Chiudi con Escape
-        toggle.addEventListener('keydown', function(e) {
-            if (e.key === 'Escape') {
-                dropdown.classList.add('hidden');
-                toggle.setAttribute('aria-expanded', 'false');
-                if (chevron) chevron.style.transform = '';
-            }
+    function init() {
+        dropdownConfigs.forEach(function(d) {
+            var toggle   = document.getElementById(d.toggleId);
+            var dropdown = document.getElementById(d.dropdownId);
+            var chevron  = document.getElementById(d.chevronId);
+            if (!toggle || !dropdown) return;
+            if (toggle.dataset.dropdownInit) return;
+            toggle.dataset.dropdownInit = '1';
+
+            toggle.addEventListener('click', function(e) {
+                e.stopPropagation();
+                var isOpen = !dropdown.classList.contains('hidden');
+                closeAll(d.dropdownId);
+                dropdown.classList.toggle('hidden', isOpen);
+                toggle.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+                if (chevron) chevron.style.transform = isOpen ? '' : 'rotate(180deg)';
+            });
+
+            toggle.addEventListener('keydown', function(e) {
+                if (e.key === 'Escape') {
+                    dropdown.classList.add('hidden');
+                    toggle.setAttribute('aria-expanded', 'false');
+                    if (chevron) chevron.style.transform = '';
+                }
+            });
         });
-    });
+
+        document.removeEventListener('click', handleOutsideClick);
+        document.addEventListener('click', handleOutsideClick);
+    }
+
+    document.addEventListener('turbo:load', init);
+    document.addEventListener('DOMContentLoaded', init);
 })();
 
 window.setTheme = function(pref) {
     localStorage.setItem('pic_theme', pref);
     applyTheme(pref);
-    document.getElementById('theme-dropdown').classList.add('hidden');
-    document.getElementById('theme-chevron').style.transform = '';
-    document.getElementById('theme-toggle').setAttribute('aria-expanded', 'false');
+    var d = document.getElementById('theme-dropdown');
+    var c = document.getElementById('theme-chevron');
+    var t = document.getElementById('theme-toggle');
+    if (d) d.classList.add('hidden');
+    if (c) c.style.transform = '';
+    if (t) t.setAttribute('aria-expanded', 'false');
 };
 </script>


### PR DESCRIPTION
## Summary

- Fixed \`TypeError: Cannot read properties of null (reading 'addEventListener')\` during Turbo Drive navigation
- Refactored header dropdown initialization to be Turbo-aware

## Root cause

Turbo Drive extracts \`data-turbo-permanent\` elements from the document *before* executing inline scripts on each navigation. \`getElementById\` calls in \`baseof.html\` targeting \`#mobile-menu-overlay\` and \`#mobile-menu-close\` (both inside \`#mobile-menu-container data-turbo-permanent\`) were returning null, causing the TypeError at \`.addEventListener\`.

## Changes

- \`baseof.html\`: added null checks before calling \`addEventListener\` on permanent element references
- \`header.html\`: refactored dropdown init from an immediate IIFE to a deferred function called on \`turbo:load\` / \`DOMContentLoaded\`, with a named outside-click handler to prevent listener accumulation across navigations

## Test plan

- [x] Navigate between sidebar links — no JS errors in console
- [x] Mobile menu opens and closes correctly after Turbo navigation
- [x] Header platform and social dropdowns open/close correctly