### PR TITLE
fix: render non-clickable div for special thanks entries without URL

### DIFF
--- a/themes/picnew/layouts/sostieni/list.html
+++ b/themes/picnew/layouts/sostieni/list.html
@@ -158,6 +158,7 @@
         <p class="text-pod-gray mb-6">Persone che hanno contribuito in modo straordinario alla nascita o alla crescita di questo progetto. Di sicuro avrò dimenticato qualcuno: non me ne vogliate, anzi fatemelo presente e rimedierò.</p>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {{ range . }}
+            {{ if and .url (ne .url "#") }}
             <a href="{{ .url }}" target="_blank" rel="noopener noreferrer"
                 class="flex items-center justify-between bg-pod-card border border-white/5 hover:border-pod-orange/50 rounded-2xl p-6 transition-all group">
                 <div class="flex flex-col">
@@ -166,13 +167,21 @@
                     <span class="text-sm text-pod-gray">{{ . }}</span>
                     {{ end }}
                 </div>
-                {{ if ne .url "#" }}
                 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-pod-gray group-hover:text-pod-orange transition-colors flex-shrink-0 ml-4">
                     <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
                     <polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>
                 </svg>
-                {{ end }}
             </a>
+            {{ else }}
+            <div class="flex items-center justify-between bg-pod-card border border-white/5 rounded-2xl p-6">
+                <div class="flex flex-col">
+                    <span class="text-lg font-semibold mb-1">{{ .name }}</span>
+                    {{ with .note }}
+                    <span class="text-sm text-pod-gray">{{ . }}</span>
+                    {{ end }}
+                </div>
+            </div>
+            {{ end }}
             {{ end }}
         </div>
     </section>


### PR DESCRIPTION
## Summary

- Special thanks entries with `url = "#"` were wrapped in `<a href="#">` which caused a page reload on click (Turbo interprets `#` as a navigation)
- Entries with no URL or `url = "#"` are now rendered as a non-interactive `<div>` instead of an `<a>`

## Test plan

- [x] Open `/sostieni/` and verify special thanks entries with `#` are not clickable and don't reload the page
- [x] Verify entries with real URLs still open correctly in a new tab