### PR TITLE
fix: hide platform and social header dropdowns on mobile

### DIFF
--- a/themes/picnew/layouts/partials/header.html
+++ b/themes/picnew/layouts/partials/header.html
@@ -83,7 +83,7 @@
 
         {{/* Dropdown Piattaforme */}}
         {{ if or $rss $podcasts }}
-        <div class="relative" id="platforms-dropdown-container">
+        <div class="relative hidden lg:block" id="platforms-dropdown-container">
             <button id="platforms-dropdown-toggle"
                 class="flex items-center gap-1.5 text-pod-gray hover:text-pod-orange transition-colors flex-shrink-0 text-sm font-mono"
                 aria-label="Ascolta su..." title="Ascolta su..." aria-expanded="false" aria-controls="platforms-dropdown" aria-haspopup="true">
@@ -125,7 +125,7 @@
 
         {{/* Dropdown Social/Contatti */}}
         {{ if or $socials $community .Site.Params.podcast.email }}
-        <div class="relative" id="social-dropdown-container">
+        <div class="relative hidden lg:block" id="social-dropdown-container">
             <button id="social-dropdown-toggle"
                 class="flex items-center gap-1.5 text-pod-gray hover:text-pod-orange transition-colors flex-shrink-0 text-sm font-mono"
                 aria-label="Seguici su..." title="Seguici su..." aria-expanded="false" aria-controls="social-dropdown" aria-haspopup="true">

--- a/themes/picnew/layouts/partials/header.html
+++ b/themes/picnew/layouts/partials/header.html
@@ -83,7 +83,7 @@
 
         {{/* Dropdown Piattaforme */}}
         {{ if or $rss $podcasts }}
-        <div class="relative hidden lg:block" id="platforms-dropdown-container">
+        <div class="relative hidden lg:flex" id="platforms-dropdown-container">
             <button id="platforms-dropdown-toggle"
                 class="flex items-center gap-1.5 text-pod-gray hover:text-pod-orange transition-colors flex-shrink-0 text-sm font-mono"
                 aria-label="Ascolta su..." title="Ascolta su..." aria-expanded="false" aria-controls="platforms-dropdown" aria-haspopup="true">
@@ -125,7 +125,7 @@
 
         {{/* Dropdown Social/Contatti */}}
         {{ if or $socials $community .Site.Params.podcast.email }}
-        <div class="relative hidden lg:block" id="social-dropdown-container">
+        <div class="relative hidden lg:flex" id="social-dropdown-container">
             <button id="social-dropdown-toggle"
                 class="flex items-center gap-1.5 text-pod-gray hover:text-pod-orange transition-colors flex-shrink-0 text-sm font-mono"
                 aria-label="Seguici su..." title="Seguici su..." aria-expanded="false" aria-controls="social-dropdown" aria-haspopup="true">


### PR DESCRIPTION
## Summary

- I dropdown piattaforme e social/contatti nell'header sono ora nascosti su schermi < 1024px (`hidden lg:block`)
- Su mobile questi link sono già accessibili nel menu hamburger laterale

## Test plan

- [ ] Su mobile (< 1024px) verificare che i due dropdown non siano visibili nell'header
- [ ] Su desktop (≥ 1024px) verificare che i dropdown appaiano normalmente