### PR TITLE
fix: show sidebar scrollbar only when menu is expanded

### DIFF
--- a/themes/picnew/assets/css/main.css
+++ b/themes/picnew/assets/css/main.css
@@ -24,6 +24,10 @@ html.light {
 html.light ::-webkit-scrollbar-thumb { background: #c8bdb4; }
 
 /* ===== GLASS SIDEBAR ===== */
+.glass-sidebar:hover nav {
+    overflow-y: auto;
+}
+
 .glass-sidebar {
     background: rgba(20, 20, 20, 0.85);
     backdrop-filter: blur(12px);

--- a/themes/picnew/layouts/partials/sidebar.html
+++ b/themes/picnew/layouts/partials/sidebar.html
@@ -6,7 +6,7 @@
         </a>
     </div>
 
-    <nav class="flex-1 w-full space-y-1 px-4 overflow-y-auto" aria-label="Navigazione principale">
+    <nav class="flex-1 w-full space-y-1 px-4 overflow-y-hidden" aria-label="Navigazione principale">
         <a href="{{ .Site.Home.RelPermalink }}" aria-label="Home"
             class="flex items-center p-2 rounded-lg hover:bg-white/5 transition-all duration-300 {{ if .IsHome }}active-link text-white{{ else }}text-pod-gray hover:text-white{{ end }}">
             <div class="flex-shrink-0">


### PR DESCRIPTION
## Summary

- La scrollbar della nav nella sidebar desktop era sempre visibile anche a menu chiuso
- Rimosso `overflow-y-auto` dalla classe Tailwind del `<nav>` e sostituito con `overflow-y-hidden`
- Aggiunta regola CSS `.glass-sidebar:hover nav { overflow-y: auto; }` per abilitare la scrollbar solo quando la sidebar è espansa (hover)