### PR TITLE
feat: expand sidebar logo when menu is hovered open

### DIFF
--- a/themes/picnew/assets/css/main.css
+++ b/themes/picnew/assets/css/main.css
@@ -27,6 +27,10 @@ html.light ::-webkit-scrollbar-thumb { background: #c8bdb4; }
 .glass-sidebar:hover nav {
     overflow-y: auto;
 }
+.glass-sidebar:hover img {
+    width: 5rem;
+    height: 5rem;
+}
 
 .glass-sidebar {
     background: rgba(20, 20, 20, 0.85);

--- a/themes/picnew/assets/css/main.css
+++ b/themes/picnew/assets/css/main.css
@@ -24,6 +24,10 @@ html.light {
 html.light ::-webkit-scrollbar-thumb { background: #c8bdb4; }
 
 /* ===== GLASS SIDEBAR ===== */
+.glass-sidebar:hover nav {
+    overflow-y: auto;
+}
+
 .glass-sidebar {
     background: rgba(20, 20, 20, 0.85);
     backdrop-filter: blur(12px);

--- a/themes/picnew/layouts/partials/sidebar.html
+++ b/themes/picnew/layouts/partials/sidebar.html
@@ -6,7 +6,7 @@
         </a>
     </div>
 
-    <nav class="flex-1 w-full space-y-1 px-4 overflow-y-auto" aria-label="Navigazione principale">
+    <nav class="flex-1 w-full space-y-1 px-4 overflow-y-hidden" aria-label="Navigazione principale">
         <a href="{{ .Site.Home.RelPermalink }}" aria-label="Home"
             class="flex items-center p-2 rounded-lg hover:bg-white/5 transition-all duration-300 {{ if .IsHome }}active-link text-white{{ else }}text-pod-gray hover:text-white{{ end }}">
             <div class="flex-shrink-0">

--- a/themes/picnew/layouts/partials/sidebar.html
+++ b/themes/picnew/layouts/partials/sidebar.html
@@ -2,7 +2,7 @@
 <aside class="glass-sidebar w-20 hover:w-64 transition-all duration-300 ease-in-out flex flex-col items-center py-4 lg:py-8 z-50 group" style="height: calc(100vh - 6rem)" aria-label="Barra laterale di navigazione">
     <div class="mb-4 lg:mb-12">
         <a href="{{ .Site.Home.RelPermalink }}" aria-label="Home — {{ .Site.Title }}">
-            <img src="{{ .Site.Params.podcast.image | absURL }}" alt="" class="w-10 h-10 rounded-lg border border-pod-orange/50 group-hover:scale-110 transition-transform">
+            <img src="{{ .Site.Params.podcast.image | absURL }}" alt="" class="w-10 h-10 rounded-lg border border-pod-orange/50 transition-all duration-300">
         </a>
     </div>
 


### PR DESCRIPTION
## Summary

- Il logo nella sidebar desktop ora si espande da 40px a 80px quando il menu viene aperto (hover)
- Rimosso `group-hover:scale-110` e sostituito con una transizione reale sulla dimensione via CSS custom
- Aggiunta regola `.glass-sidebar:hover img` in `main.css` per evitare dipendenza dalla generazione delle classi Tailwind