### PR TITLE
fix: restore chapters and transcript buttons after page reload

### DIFF
--- a/themes/picnew/layouts/partials/footer-player.html
+++ b/themes/picnew/layouts/partials/footer-player.html
@@ -162,6 +162,8 @@
     let currentChapters = [];
     let currentTranscript = [];
     let currentTranscriptIndex = -1;
+    let activeChaptersUrl = null;
+    let activeTranscriptUrl = null;
 
     const collapseBtn = document.getElementById('player-collapse-btn');
     const miniPlayBtn = document.getElementById('player-mini-play');
@@ -260,6 +262,7 @@
         }
 
         // Load chapters if available
+        activeChaptersUrl = chaptersUrl || null;
         if (chaptersUrl) {
             fetch(chaptersUrl)
                 .then(response => response.json())
@@ -279,6 +282,7 @@
         }
 
         // Load transcript if available
+        activeTranscriptUrl = transcriptUrl || null;
         if (transcriptUrl) {
             fetch(transcriptUrl)
                 .then(response => response.text())
@@ -431,15 +435,24 @@
                 audio.playbackRate = state.playbackRate;
             }
 
-            if (state.chaptersUrl) {
-                fetch(state.chaptersUrl)
+            // Fall back to playlist data if saved state is missing chapter/transcript URLs
+            const playlist = window.__playlist || [];
+            const matchedEp = playlist.find(ep => state.url && state.url.includes(ep.audio));
+            const chaptersUrl = state.chaptersUrl || (matchedEp && matchedEp.chapters) || null;
+            const transcriptUrl = state.transcriptUrl || (matchedEp && matchedEp.transcript) || null;
+            activeChaptersUrl = chaptersUrl;
+            activeTranscriptUrl = transcriptUrl;
+
+            if (chaptersUrl) {
+                fetch(chaptersUrl)
                     .then(response => response.json())
                     .then(data => {
                         if (data && data.chapters) renderChapters(data.chapters);
-                    });
+                    })
+                    .catch(() => {});
             }
-            if (state.transcriptUrl) {
-                fetch(state.transcriptUrl)
+            if (transcriptUrl) {
+                fetch(transcriptUrl)
                     .then(response => response.text())
                     .then(text => renderTranscript(parseSRT(text)))
                     .catch(() => {});
@@ -476,6 +489,9 @@
 
             audio.src = ep.audio;
             audio.load();
+
+            activeChaptersUrl = ep.chapters || null;
+            activeTranscriptUrl = ep.transcript || null;
 
             if (ep.chapters) {
                 fetch(ep.chapters)
@@ -553,8 +569,8 @@
             currentTime: audio.currentTime,
             shouldPlay: !audio.paused,
             playbackRate: audio.playbackRate,
-            chaptersUrl: localStorage.getItem('pic_player_state') ? JSON.parse(localStorage.getItem('pic_player_state')).chaptersUrl : null,
-            transcriptUrl: localStorage.getItem('pic_player_state') ? JSON.parse(localStorage.getItem('pic_player_state')).transcriptUrl : null
+            chaptersUrl: activeChaptersUrl,
+            transcriptUrl: activeTranscriptUrl
         };
         localStorage.setItem('pic_player_state', JSON.stringify(state));
     }, 2000);


### PR DESCRIPTION
## Problema

In produzione i pulsanti "Capitoli" e "Trascrizione" del player non comparivano mai, anche per gli episodi che dispongono di entrambi i file.

## Causa

Il periodic saver (ogni 2s) leggeva `chaptersUrl`/`transcriptUrl` dallo stesso `localStorage`, che nelle prime iterazioni è ancora vuoto (prima che `initPlayer` lo scriva). Questo causava il salvataggio di `null` in quei campi. Al reload successivo, `initPlayer` trovava `chaptersUrl: null` e non caricava mai i dati, lasciando i pulsanti nascosti per sempre.

## Fix

- **Variabili di modulo** `activeChaptersUrl` e `activeTranscriptUrl`: aggiornate da `playEpisode` e da `initPlayer`, usate direttamente dal periodic saver invece di rileggere dal `localStorage`.
- **Fallback nel restore**: quando `initPlayer` trova uno stato salvato con `chaptersUrl: null`, cerca l'episodio corrispondente in `window.__playlist` e usa le sue URL. Questo risolve anche gli utenti già in produzione con stato stale nel browser.

## Test plan

- [x] Visitare la homepage o la pagina di un episodio con capitoli e trascrizione
- [x] Verificare che i pulsanti ≡ (capitoli) e 📄 (trascrizione) compaiano nel footer player
- [x] Ricaricare la pagina e verificare che i pulsanti rimangano visibili
- [x] Aprire le DevTools → Application → Local Storage e verificare che `chaptersUrl` e `transcriptUrl` siano valorizzati correttamente
- [x] Verificare che il comportamento sia corretto anche per episodi senza capitoli/trascrizione (bottoni assenti)