### PR TITLE
fix: make tags clickable and visually consistent

### DIFF
--- a/themes/picnew/layouts/_default/taxonomy.html
+++ b/themes/picnew/layouts/_default/taxonomy.html
@@ -32,8 +32,8 @@
             <p class="text-sm text-pod-gray mb-6 line-clamp-2">{{ .Summary }}</p>
             <div class="flex items-center justify-between mt-auto">
                 <div class="flex space-x-2">
-                    {{ range .Params.tags | first 2 }}
-                    <span class="text-[10px] bg-white/5 px-2 py-1 rounded">#{{ . }}</span>
+                    {{ range first 2 (.GetTerms "tags") }}
+                    <a href="{{ .Permalink }}" class="text-[10px] bg-white/5 px-2 py-1 rounded hover:text-pod-orange transition-colors">#{{ .Title | lower }}</a>
                     {{ end }}
                 </div>
                 <div class="flex items-center space-x-3">

--- a/themes/picnew/layouts/blog/list.html
+++ b/themes/picnew/layouts/blog/list.html
@@ -23,8 +23,8 @@
             <p class="text-sm text-pod-gray mb-6 line-clamp-2">{{ .Summary }}</p>
             <div class="flex items-center justify-between">
                 <div class="flex space-x-2">
-                    {{ range .Params.tags | first 2 }}
-                    <span class="text-[10px] bg-white/5 px-2 py-1 rounded">#{{ . }}</span>
+                    {{ range first 2 (.GetTerms "tags") }}
+                    <a href="{{ .Permalink }}" class="text-[10px] bg-white/5 px-2 py-1 rounded hover:text-pod-orange transition-colors">#{{ .Title | lower }}</a>
                     {{ end }}
                 </div>
                 <a href="{{ .Permalink }}" class="text-pod-orange hover:underline text-sm font-bold">Leggi →</a>

--- a/themes/picnew/layouts/blog/single.html
+++ b/themes/picnew/layouts/blog/single.html
@@ -12,10 +12,10 @@
             <img src="{{ . }}" alt="{{ $.Title }}" class="object-contain w-full h-full">
         </div>
         {{ end }}
-        {{ with .Params.tags }}
+        {{ with .GetTerms "tags" }}
         <div class="flex flex-wrap justify-center gap-2 mb-8">
             {{ range . }}
-            <span class="text-xs bg-white/5 hover:bg-pod-orange/20 px-3 py-1 rounded-full transition-colors border border-white/5 text-pod-gray">#{{ . }}</span>
+            <a href="{{ .Permalink }}" class="text-xs bg-white/5 hover:bg-pod-orange/20 px-3 py-1 rounded-full transition-colors border border-white/5 text-pod-gray">#{{ .Title | lower }}</a>
             {{ end }}
         </div>
         {{ end }}

--- a/themes/picnew/layouts/index.html
+++ b/themes/picnew/layouts/index.html
@@ -19,10 +19,10 @@
                 <h1 class="text-4xl md:text-5xl font-extrabold mb-6 tracking-tight leading-tight max-w-4xl">
                     <a href="{{ $latest.Permalink }}" class="hover:text-pod-orange transition-colors">{{ $latest.Title }}</a>
                 </h1>
-                {{ with $latest.Params.tags }}
+                {{ with $latest.GetTerms "tags" }}
                 <div class="flex flex-wrap gap-2 mb-4">
                     {{ range . | first 3 }}
-                    <span class="text-[10px] bg-white/5 px-2 py-1 rounded">#{{ . }}</span>
+                    <a href="{{ .Permalink }}" class="text-[10px] bg-white/5 px-2 py-1 rounded hover:text-pod-orange transition-colors">#{{ .Title | lower }}</a>
                     {{ end }}
                 </div>
                 {{ end }}
@@ -85,8 +85,8 @@
             <p class="text-sm text-pod-gray line-clamp-2">{{ .Summary }}</p>
             <div class="flex items-center justify-between mt-auto pt-6">
                 <div class="flex space-x-2">
-                    {{ range .Params.tags | first 2 }}
-                    <span class="text-[10px] bg-white/5 px-2 py-1 rounded">#{{ . }}</span>
+                    {{ range first 2 (.GetTerms "tags") }}
+                    <a href="{{ .Permalink }}" class="text-[10px] bg-white/5 px-2 py-1 rounded hover:text-pod-orange transition-colors">#{{ .Title | lower }}</a>
                     {{ end }}
                 </div>
                 {{ with .Params.audio }}
@@ -131,8 +131,8 @@
             <p class="text-sm text-pod-gray line-clamp-2">{{ .Summary }}</p>
             <div class="flex items-center justify-between mt-auto pt-6">
                 <div class="flex space-x-2">
-                    {{ range .Params.tags | first 2 }}
-                    <span class="text-[10px] bg-white/5 px-2 py-1 rounded">#{{ . }}</span>
+                    {{ range first 2 (.GetTerms "tags") }}
+                    <a href="{{ .Permalink }}" class="text-[10px] bg-white/5 px-2 py-1 rounded hover:text-pod-orange transition-colors">#{{ .Title | lower }}</a>
                     {{ end }}
                 </div>
                 <a href="{{ .Permalink }}" class="text-pod-orange hover:underline text-sm font-bold">Scopri →</a>

--- a/themes/picnew/layouts/podcast/list.html
+++ b/themes/picnew/layouts/podcast/list.html
@@ -35,8 +35,8 @@
             <p class="text-sm text-pod-gray mb-6 line-clamp-2">{{ .Summary }}</p>
             <div class="flex items-center justify-between mt-auto">
                 <div class="flex space-x-2">
-                    {{ range first 2 (.Params.tags | default slice) }}
-                    <span class="text-[10px] bg-white/5 px-2 py-1 rounded">#{{ . }}</span>
+                    {{ range first 2 (.GetTerms "tags") }}
+                    <a href="{{ .Permalink }}" class="text-[10px] bg-white/5 px-2 py-1 rounded hover:text-pod-orange transition-colors">#{{ .Title | lower }}</a>
                     {{ end }}
                 </div>
                 <div class="flex items-center space-x-3">

--- a/themes/picnew/layouts/podcast/single.html
+++ b/themes/picnew/layouts/podcast/single.html
@@ -35,11 +35,10 @@
         </div>
         <h1 class="text-4xl md:text-6xl font-extrabold mb-8 tracking-tight leading-tight">{{ .Title }}</h1>
 
-        {{ with .Params.tags }}
+        {{ with .GetTerms "tags" }}
         <div class="flex flex-wrap justify-center gap-2 mb-8">
             {{ range . }}
-            <a href="{{ printf "/tags/%s/" (. | urlize) | relURL }}"
-                class="text-xs bg-white/5 hover:bg-pod-orange/20 px-3 py-1 rounded-full transition-colors border border-white/5 text-pod-gray">#{{ . }}</a>
+            <a href="{{ .Permalink }}" class="text-xs bg-white/5 hover:bg-pod-orange/20 px-3 py-1 rounded-full transition-colors border border-white/5 text-pod-gray">#{{ .Title | lower }}</a>
             {{ end }}
         </div>
         {{ end }}


### PR DESCRIPTION
## Summary

- Le tag in homepage, lista episodi, lista news e pagine singole erano rese come `<span>` non cliccabili — ora sono `<a>` che puntano alle pagine taxonomy generate da Hugo
- Sostituito `range .Params.tags` con `.GetTerms "tags"` in tutti i layout, eliminando anche la costruzione manuale dell'URL presente in `podcast/single.html`
- Aggiunto `| lower` al titolo per garantire visualizzazione coerente in minuscolo, con hover arancione uniforme al resto del sito

**File modificati:** `layouts/index.html`, `layouts/podcast/list.html`, `layouts/podcast/single.html`, `layouts/blog/list.html`, `layouts/blog/single.html`, `layouts/_default/taxonomy.html`

## Test plan

- [x] Homepage: le tag negli episodi recenti e nelle news sono cliccabili e portano a `/tags/{slug}/`
- [x] Lista episodi (`/episodes/`): tag cliccabili
- [x] Lista news (`/blog/`): tag cliccabili
- [x] Pagina singola episodio: tag cliccabili
- [x] Pagina singola news: tag cliccabili
- [x] Tutte le tag sono visualizzate in minuscolo con prefisso `#`
- [x] Le pagine tag (`/tags/programmazione/` ecc.) si aprono correttamente