### PR TITLE
feat: player — Fase 1 CSS quick fixes (safe area, touch targets, chapter markers)

### DIFF
--- a/themes/picnew/assets/css/main.css
+++ b/themes/picnew/assets/css/main.css
@@ -223,6 +223,15 @@ html.light .prose blockquote {
         height: 2.5rem;
     }
 
+    /* Touch target minimi 44×44px per i button del player */
+    #footer-player-container button {
+        min-width: 44px;
+        min-height: 44px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+    }
+
     /* Player mobile: collapse */
     #player-mobile-actions { display: flex; align-items: center; gap: 0.5rem; margin-left: auto; }
     #player-info { flex: 1; min-width: 0; }
@@ -242,6 +251,54 @@ html.light .prose blockquote {
         height: auto;
         aspect-ratio: 1 / 1;
     }
+}
+
+/* ============================= */
+/* ===== PLAYER ENHANCEMENTS ==== */
+/* ============================= */
+
+/* Safe area iPhone: evita che il player finisca sotto la home indicator */
+#footer-player-container footer {
+    padding-bottom: max(0.5rem, env(safe-area-inset-bottom));
+}
+
+/* Chapter markers sulla seekbar */
+#player-progress-bar .ch-marks-container {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+.ch-mark {
+    position: absolute;
+    top: 50%;
+    transform: translateX(-50%) translateY(-50%);
+    width: 2px;
+    height: 10px;
+    border-radius: 1px;
+    background: #6b7280;
+    transition: background 0.2s;
+}
+.ch-mark.past {
+    background: #E86520;
+}
+
+/* Thumb visibile sulla seekbar */
+#player-progress-bar .seek-thumb {
+    position: absolute;
+    top: 50%;
+    transform: translateX(-50%) translateY(-50%);
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 0 4px rgba(0,0,0,0.4);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+#player-progress-bar:hover .seek-thumb,
+#player-progress-bar:active .seek-thumb {
+    opacity: 1;
 }
 
 /* ============================= */

--- a/themes/picnew/layouts/partials/footer-player.html
+++ b/themes/picnew/layouts/partials/footer-player.html
@@ -94,6 +94,8 @@
                     <div class="flex-1 h-1 bg-white/10 rounded-full overflow-hidden relative group cursor-pointer" id="player-progress-bar"
                         role="slider" aria-label="Progresso della riproduzione" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" tabindex="0">
                         <div class="absolute inset-0 bg-pod-orange rounded-full" style="width: 0%" id="player-progress"></div>
+                        <div class="ch-marks-container" id="player-ch-marks"></div>
+                        <div class="seek-thumb" id="player-seek-thumb"></div>
                     </div>
                     <span class="text-[10px] font-mono text-pod-gray" id="player-duration">0:00</span>
                 </div>
@@ -158,6 +160,8 @@
     const chapterNextBtn = document.getElementById('player-chapter-next');
     const episodePrevBtn = document.getElementById('player-episode-prev');
     const episodeNextBtn = document.getElementById('player-episode-next');
+    const chMarksContainer = document.getElementById('player-ch-marks');
+    const seekThumb = document.getElementById('player-seek-thumb');
 
     let currentChapters = [];
     let currentTranscript = [];
@@ -336,11 +340,34 @@
         chapterNextBtn.classList.remove('hidden');
         chapterPrevBtn.disabled = false;
         chapterNextBtn.disabled = false;
+        if (audio.duration) renderChapterMarks();
+    }
+
+    function renderChapterMarks() {
+        chMarksContainer.innerHTML = '';
+        if (!audio.duration || !currentChapters.length) return;
+        currentChapters.forEach(chapter => {
+            const pct = (chapter.startTime / audio.duration) * 100;
+            const mark = document.createElement('div');
+            mark.className = 'ch-mark';
+            mark.style.left = pct + '%';
+            chMarksContainer.appendChild(mark);
+        });
+        updateChapterMarkColors();
+    }
+
+    function updateChapterMarkColors() {
+        const marks = chMarksContainer.querySelectorAll('.ch-mark');
+        marks.forEach((mark, i) => {
+            const isPast = audio.currentTime >= currentChapters[i].startTime;
+            mark.classList.toggle('past', isPast);
+        });
     }
 
     function hideChapters() {
         currentChapters = [];
         chaptersList.innerHTML = '';
+        chMarksContainer.innerHTML = '';
         chaptersContainer.classList.add('hidden');
         toggleChaptersBtn.classList.add('hidden');
         chapterPrevBtn.classList.add('hidden');
@@ -604,13 +631,19 @@
 
     let currentChapterIndex = -1;
 
+    audio.addEventListener('loadedmetadata', function() {
+        if (currentChapters.length) renderChapterMarks();
+    });
+
     audio.addEventListener('timeupdate', function() {
         currentTimeEl.textContent = formatTime(audio.currentTime);
         if (audio.duration) {
-            const pct = Math.round(audio.currentTime / audio.duration * 100);
+            const pct = (audio.currentTime / audio.duration) * 100;
             progress.style.width = pct + '%';
-            progressBar.setAttribute('aria-valuenow', pct);
+            progressBar.setAttribute('aria-valuenow', Math.round(pct));
+            seekThumb.style.left = pct + '%';
             if (audio.currentTime / audio.duration >= 0.9) markListened(audio.src);
+            if (currentChapters.length) updateChapterMarkColors();
         }
         if (currentChapters.length) {
             // Trova il capitolo corrente


### PR DESCRIPTION
## Sommario

Prima fase del piano di miglioramenti del player audio. Modifiche CSS non-breaking, immediatamente visibili.

- **Safe area iPhone** — `padding-bottom: max(0.5rem, env(safe-area-inset-bottom))` sul footer del player: evita che i controlli finiscano sotto la home indicator sui dispositivi con notch
- **Touch target ≥ 44px su mobile** — in `@media (max-width: 1023px)` tutti i `<button>` del player ottengono `min-width: 44px; min-height: 44px` (conforme WCAG 2.5.5)
- **Chapter markers sulla seekbar** — nuovi stili `.ch-mark` (2px × 10px, arancione `#E86520` per i capitoli già passati, grigio per i futuri) e thumb visibile da 12px che appare al hover/active
- **HTML + JS** — aggiunto `<div id="player-ch-marks">` e `<div id="player-seek-thumb">` nella seekbar; funzioni `renderChapterMarks()` e `updateChapterMarkColors()` chiamate al caricamento dei capitoli e ad ogni `timeupdate`

## Test

- [x] Desktop: player visibile, seekbar funzionante, nessun errore JS
- [x] Mobile (375×812): touch target 44×44px verificati con DevTools
- [x] Seek thumb presente nel DOM e correttamente posizionato
- [x] CSS safe area applicato correttamente