### PR TITLE
feat: player — Fase 4c landscape layout + Fase 5a/5b PWA manifest e Service Worker

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "Pensieri in codice",
+  "short_name": "Pensieri in codice",
+  "description": "Il podcast dove si ragiona da informatici. Con Valerio Galano",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0a0a0a",
+  "theme_color": "#E86520",
+  "icons": [
+    {
+      "src": "/images/pensieriincodice-locandina.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ],
+  "categories": ["entertainment", "music"],
+  "lang": "it"
+}

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,0 +1,86 @@
+const CACHE_NAME = 'pic-v1';
+const AUDIO_CACHE = 'pic-audio-v1';
+
+const STATIC_ASSETS = [
+  '/',
+  '/manifest.json',
+  '/fonts/fonts.css',
+];
+
+// Install: pre-cache static assets
+self.addEventListener('install', function(e) {
+  e.waitUntil(
+    caches.open(CACHE_NAME).then(function(cache) {
+      return cache.addAll(STATIC_ASSETS);
+    }).then(function() {
+      return self.skipWaiting();
+    })
+  );
+});
+
+// Activate: remove old caches
+self.addEventListener('activate', function(e) {
+  e.waitUntil(
+    caches.keys().then(function(keys) {
+      return Promise.all(
+        keys.filter(function(k) { return k !== CACHE_NAME && k !== AUDIO_CACHE; })
+            .map(function(k) { return caches.delete(k); })
+      );
+    }).then(function() {
+      return self.clients.claim();
+    })
+  );
+});
+
+self.addEventListener('fetch', function(e) {
+  var url = e.request.url;
+
+  // Audio files: Network-First with cache fallback
+  if (e.request.destination === 'audio' || /\.(mp3|ogg|m4a|opus|aac)(\?|$)/i.test(url)) {
+    e.respondWith(
+      fetch(e.request).then(function(response) {
+        if (response.ok) {
+          var clone = response.clone();
+          caches.open(AUDIO_CACHE).then(function(cache) { cache.put(e.request, clone); });
+        }
+        return response;
+      }).catch(function() {
+        return caches.match(e.request);
+      })
+    );
+    return;
+  }
+
+  // Navigation requests: Network-First
+  if (e.request.mode === 'navigate') {
+    e.respondWith(
+      fetch(e.request).catch(function() {
+        return caches.match(e.request).then(function(r) { return r || caches.match('/'); });
+      })
+    );
+    return;
+  }
+
+  // Static assets (CSS, JS, fonts, images): Cache-First
+  e.respondWith(
+    caches.match(e.request).then(function(cached) {
+      if (cached) return cached;
+      return fetch(e.request).then(function(response) {
+        if (response.ok && e.request.method === 'GET') {
+          var clone = response.clone();
+          caches.open(CACHE_NAME).then(function(cache) { cache.put(e.request, clone); });
+        }
+        return response;
+      });
+    })
+  );
+});
+
+// Message: cache a specific audio URL on demand
+self.addEventListener('message', function(e) {
+  if (e.data && e.data.type === 'CACHE_AUDIO' && e.data.url) {
+    caches.open(AUDIO_CACHE).then(function(cache) {
+      cache.add(e.data.url).catch(function() {});
+    });
+  }
+});

--- a/themes/picnew/assets/css/main.css
+++ b/themes/picnew/assets/css/main.css
@@ -253,6 +253,34 @@ html.light .prose blockquote {
     }
 }
 
+/* ===== MOBILE LANDSCAPE (< 1024px, orientamento orizzontale) ===== */
+@media (max-width: 1023px) and (orientation: landscape) {
+    #footer-player-container footer {
+        padding: 0.4rem 1rem;
+        min-height: auto;
+    }
+    .player-main-row { flex-direction: row; align-items: center; flex-wrap: nowrap; }
+    .player-info-col { width: auto; flex: 1; }
+    .player-controls-col { width: auto; flex: 1; margin-top: 0; padding: 0 0.5rem; }
+    .player-right-col { width: auto; margin-top: 0; justify-content: flex-end; }
+    #player-image-container { width: 2rem !important; height: 2rem !important; }
+
+    /* Expanded player in landscape: cover a sinistra, controlli a destra */
+    #player-expanded {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+    #player-expanded > div:nth-child(3) { /* cover */
+        width: 35%;
+        padding: 0.5rem;
+    }
+    #player-expanded > div:nth-child(3) .w-48 {
+        width: 100%;
+        height: auto;
+        max-width: 140px;
+    }
+}
+
 /* ============================= */
 /* ===== PLAYER ENHANCEMENTS ==== */
 /* ============================= */

--- a/themes/picnew/layouts/_default/baseof.html
+++ b/themes/picnew/layouts/_default/baseof.html
@@ -31,9 +31,11 @@
     <script>window.__playlist={{ $playlist | jsonify | safeJS }};</script>
     <link rel="icon" type="image/png" href="{{ .Site.Params.podcast.image | absURL }}">
     <link rel="apple-touch-icon" href="{{ .Site.Params.podcast.image | absURL }}">
+    <link rel="manifest" href="/manifest.json">
     {{ hugo.Generator }}
     <!-- Anti-FOUC: applica il tema prima del render -->
     <script>(function(){var p=localStorage.getItem('pic_theme')||'system',h=document.documentElement;h.classList.remove('light','dark');if(p==='dark')h.classList.add('dark');else if(p==='light')h.classList.add('light');else h.classList.add(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');}());</script>
+    <script>if('serviceWorker' in navigator){window.addEventListener('load',function(){navigator.serviceWorker.register('/sw.js').catch(function(){});});}</script>
 </head>
 <body class="bg-pod-black text-white font-sans selection:bg-pod-orange selection:text-white overflow-hidden h-screen flex">
 


### PR DESCRIPTION
## Sommario

**Fase 4c — Landscape layout**
- `@media (max-width: 1023px) and (orientation: landscape)`: mini-player con layout orizzontale compatto, dimensioni ridotte, padding minimale
- Expanded player in landscape: struttura adattata per orientamento orizzontale

**Fase 5a — PWA Manifest**
- `static/manifest.json`: `name`, `short_name`, `description`, `start_url: /`, `display: standalone`, `theme_color: #E86520`, `background_color: #0a0a0a`, icona 512×512
- `<link rel="manifest" href="/manifest.json">` in `baseof.html`

**Fase 5b — Service Worker**
- `static/sw.js` con tre strategie:
  - **Cache-First** per assets statici (CSS, JS, font, immagini)
  - **Network-First** per audio (`.mp3`, `.ogg`, ecc.) con fallback alla cache
  - **Network-First** per navigate con fallback alla cache
- Registrazione in `baseof.html` con `navigator.serviceWorker.register('/sw.js')`
- Messaggio `CACHE_AUDIO` per precaching on-demand di un episodio
- Pulizia automatica delle cache obsolete all'attivazione

## Test

- [x] `/manifest.json` risponde 200
- [x] `/sw.js` risponde 200
- [x] `<link rel="manifest">` presente nell'HTML
- [x] Service Worker registrato senza errori in console